### PR TITLE
Update Events.h

### DIFF
--- a/SOUI/include/event/Events.h
+++ b/SOUI/include/event/Events.h
@@ -144,8 +144,10 @@ namespace SOUI
             , sender(pSender)
             , bubbleUp(true)
         {
-            idFrom = pSender->GetID();
-            nameFrom = pSender->GetName();
+            if(NULL!=pSender) {
+	    	idFrom = pSender->GetID();
+            	nameFrom = pSender->GetName();
+            }
         }
 
         virtual ~EventArgs(void) {}

--- a/SOUI/include/event/Events.h
+++ b/SOUI/include/event/Events.h
@@ -147,7 +147,10 @@ namespace SOUI
             if(NULL!=pSender) {
 	    	idFrom = pSender->GetID();
             	nameFrom = pSender->GetName();
-            }
+            } else {
+	    	idFrom = 0;
+		nameFrom = NULL;
+	    }
         }
 
         virtual ~EventArgs(void) {}


### PR DESCRIPTION
当事件产生自非SOUI对象时，可能传入NULL.(如来自工作线程的事件通知)