### PR TITLE
修复SFreeMoveWindow控件在拉伸时，光标形状自动切换成默认形状的bug

### DIFF
--- a/controls.extend/SFreeMoveWindow.cpp
+++ b/controls.extend/SFreeMoveWindow.cpp
@@ -70,6 +70,31 @@ namespace SOUI
 		return dwHit;
 	}
 
+	void SFreeMoveWindow::SetCursorWrapper(DWORD dwHit)
+	{
+		switch (dwHit)
+		{
+		case HT_CAPTION:
+			::SetCursor(GETRESPROVIDER->LoadCursor(_T("sizeall")));
+			break;
+		case HT_LEFT:
+		case HT_RIGHT:
+			::SetCursor(GETRESPROVIDER->LoadCursor(_T("sizewe")));
+			break;
+		case HT_TOP:
+		case HT_BOTTOM:
+			::SetCursor(GETRESPROVIDER->LoadCursor(_T("sizens")));
+			break;
+		case HT_LEFT | HT_TOP:
+		case HT_RIGHT | HT_BOTTOM:
+			::SetCursor(GETRESPROVIDER->LoadCursor(_T("sizenwse")));
+			break;
+		case HT_LEFT | HT_BOTTOM:
+		case HT_RIGHT | HT_TOP:
+			::SetCursor(GETRESPROVIDER->LoadCursor(_T("sizenesw")));
+			break;
+		}
+	}
 	void SFreeMoveWindow::OnNcLButtonDown(UINT nFlags, CPoint pt)
 	{
 		if (m_bResizable)
@@ -78,6 +103,7 @@ namespace SOUI
 			m_bDraging = TRUE;
 			m_ptClick = pt;
 			m_rcClickWndPos = GetWindowRect();
+			SetCursorWrapper(m_dwHit);
 		}
 		else
 		{
@@ -103,30 +129,7 @@ namespace SOUI
 		if (!m_bDraging)
 		{
 			m_dwHit = HitTest(pt);
-
-			m_dwHit = HitTest(pt);
-			switch (m_dwHit)
-			{
-			case HT_CAPTION:
-				::SetCursor(GETRESPROVIDER->LoadCursor(_T("sizeall")));
-				break;
-			case HT_LEFT:
-			case HT_RIGHT:
-				::SetCursor(GETRESPROVIDER->LoadCursor(_T("sizewe")));
-				break;
-			case HT_TOP:
-			case HT_BOTTOM:
-				::SetCursor(GETRESPROVIDER->LoadCursor(_T("sizens")));
-				break;
-			case HT_LEFT | HT_TOP:
-			case HT_RIGHT | HT_BOTTOM:
-				::SetCursor(GETRESPROVIDER->LoadCursor(_T("sizenwse")));
-				break;
-			case HT_LEFT | HT_BOTTOM:
-			case HT_RIGHT | HT_TOP:
-				::SetCursor(GETRESPROVIDER->LoadCursor(_T("sizenesw")));
-				break;
-			}
+			SetCursorWrapper(m_dwHit);
 		}
 		else
 		{

--- a/controls.extend/SFreeMoveWindow.h
+++ b/controls.extend/SFreeMoveWindow.h
@@ -17,6 +17,7 @@ namespace SOUI
 		void OnNcMouseMove(UINT nFlags, CPoint pt);
 		void OnNcPaint(IRenderTarget * pRT);
 		DWORD HitTest(CPoint pt);
+		void SetCursorWrapper(DWORD dwHit);
 
         SOUI_MSG_MAP_BEGIN()
 			MSG_WM_NCLBUTTONDOWN(OnNcLButtonDown)


### PR DESCRIPTION
如题，SFreeMoveWindow控件之前就存在这个问题的，光标移动在控件Nc区域的时候，会自动切换光标形状，告知用户此时控件可拖伸或移动，如"sizewe"，但是目前存在这么一个bug，用户在此Nc区域按住左键，然后拉伸窗口或移动窗口时，光标形状会切换回默认，此PR修复了此问题