### PR TITLE
SSkinImgList在缩放时对m_arrStateMap做了一次=拷贝，但因只是浅拷贝，当资源释放时，出现多次对同一个地方进行销毁，引…

### DIFF
--- a/utilities/include/souicoll.h
+++ b/utilities/include/souicoll.h
@@ -484,6 +484,8 @@ public:
     const E& operator[]( size_t iElement ) const;
     E& operator[]( size_t iElement );
 
+    SArray< E, ETraits > & operator = (const SArray< E, ETraits >& src);
+
     void InsertAt( size_t iElement, INARGTYPE element, size_t nCount = 1 );
     void InsertArrayAt( size_t iStart, const SArray< E, ETraits >* paNew );
     void RemoveAt( size_t iElement, size_t nCount = 1 );
@@ -510,6 +512,13 @@ public:
     ~SArray();
 
 };
+
+template< typename E, class ETraits /*= CElementTraits< E > */>
+SOUI::SArray< E, ETraits > & SOUI::SArray<E, ETraits>::operator=(const SArray< E, ETraits >& src)
+{
+    this->Copy(src);
+    return *this;
+}
 
 template< typename E, class ETraits >
 inline size_t SArray< E, ETraits >::GetCount() const


### PR DESCRIPTION
…起奔溃，为避免这种问题，现在对SArray的=运算符重写。