### PR TITLE
修复 ListView 适配器 isEmpty 默认实现错误问题

### DIFF
--- a/SOUI/include/helper/SAdapterBase.h
+++ b/SOUI/include/helper/SAdapterBase.h
@@ -135,7 +135,7 @@ namespace SOUI
 
         virtual bool isEmpty()
         {
-            return getCount()>0;
+            return getCount() <= 0;
         }
 
         virtual ULONG_PTR getItemData(int position){


### PR DESCRIPTION
https://github.com/BensonLaur/soui-1/blob/fix-LvAdatperImpl-isEmpty/SOUI/include/helper/SAdapterBase.h#L136-L139
