### PR TITLE
fix vs2019使用新版本SDK以后报负下标 

### DIFF
--- a/third-part/mhook/mhook.vcproj
+++ b/third-part/mhook/mhook.vcproj
@@ -29,7 +29,7 @@
 				GeneratePreprocessedFile="0"
 				ObjectFile="..\..\obj\release\mhook\"
 				Optimization ="1"
-				PreprocessorDefinitions="_WINDOWS,UNICODE,WIN32,_CRT_SECURE_NO_WARNINGS,DISABLE_ODPRINTF,QT_NO_DYNAMIC_CAST,NDEBUG"
+				PreprocessorDefinitions="_WINDOWS,UNICODE,WIN32,_CRT_SECURE_NO_WARNINGS,DISABLE_ODPRINTF,QT_NO_DYNAMIC_CAST,NDEBUG,WINDOWS_IGNORE_PACKING_MISMATCH"
 				ProgramDataBaseFileName="$(IntDir)"
 				RuntimeLibrary="0"
 				SuppressStartupBanner="true"
@@ -56,7 +56,7 @@
 				Name="VCPreLinkEventTool" />
 			<Tool
 				Name="VCResourceCompilerTool"
-				PreprocessorDefinitions="_WINDOWS,UNICODE,WIN32,_CRT_SECURE_NO_WARNINGS,DISABLE_ODPRINTF,QT_NO_DYNAMIC_CAST"
+				PreprocessorDefinitions="_WINDOWS,UNICODE,WIN32,_CRT_SECURE_NO_WARNINGS,DISABLE_ODPRINTF,QT_NO_DYNAMIC_CAST,WINDOWS_IGNORE_PACKING_MISMATCH"
 				ResourceOutputFileName="$(OutDir)\$(InputName).res" />
 		</Configuration>
 		<Configuration
@@ -78,7 +78,7 @@
 				GeneratePreprocessedFile="0"
 				ObjectFile="..\..\obj\debug\mhook\"
 				Optimization ="4"
-				PreprocessorDefinitions="_WINDOWS,UNICODE,WIN32,_CRT_SECURE_NO_WARNINGS,DISABLE_ODPRINTF,QT_NO_DYNAMIC_CAST"
+				PreprocessorDefinitions="_WINDOWS,UNICODE,WIN32,_CRT_SECURE_NO_WARNINGS,DISABLE_ODPRINTF,QT_NO_DYNAMIC_CAST,WINDOWS_IGNORE_PACKING_MISMATCH"
 				ProgramDataBaseFileName="$(IntDir)"
 				RuntimeLibrary="1"
 				SuppressStartupBanner="true"
@@ -105,7 +105,7 @@
 				Name="VCPreLinkEventTool" />
 			<Tool
 				Name="VCResourceCompilerTool"
-				PreprocessorDefinitions="_WINDOWS,UNICODE,WIN32,_CRT_SECURE_NO_WARNINGS,DISABLE_ODPRINTF,QT_NO_DYNAMIC_CAST,_DEBUG"
+				PreprocessorDefinitions="_WINDOWS,UNICODE,WIN32,_CRT_SECURE_NO_WARNINGS,DISABLE_ODPRINTF,QT_NO_DYNAMIC_CAST,_DEBUG,WINDOWS_IGNORE_PACKING_MISMATCH"
 				ResourceOutputFileName="$(OutDir)\$(InputName).res" />
 		</Configuration>
 	</Configurations>


### PR DESCRIPTION
修复vs2019使用新版本SDK以后报负下标

vs2019使用新版本SDK以后报负下标
http://www.soui.vip/forum.php?mod=viewthread&tid=801
(出处: SOUI官方论坛)
